### PR TITLE
Consistent use of 'destroy' to better indicate destructive power over al...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 /.rvmrc
+/.idea

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Once this new stack is stable or has run for a while you can choose to delete th
 ### Destroying a stack
 So you are done with this application or environment, you can destroy it easily as well.
 
-    desc "clean up everything"
+    desc "destroy application and all configured environments"
     task :teardown do |t, args|
       EbDeployer.destroy(:application => "ebtest-simple")
     end

--- a/lib/eb_deployer.rb
+++ b/lib/eb_deployer.rb
@@ -174,6 +174,16 @@ module EbDeployer
     strategy.deploy(version_label, env_settings)
   end
 
+  ##
+  # WARNING: USE extreme caution, this will destroy *all* Elastic Beanstalk
+  #  environments and the Elastic Beanstalk application itself.
+  #  i.e. do not issue a destroy when you have other environments
+  #   under the same :application that you wish to keep running.
+  #
+  #  options: a hash
+  #     :application     application name
+  #
+
   def self.destroy(opts)
     if region = opts[:region]
       AWS.config(:region => region)
@@ -183,7 +193,7 @@ module EbDeployer
     bs = opts[:bs_driver] || Beanstalk.new
     s3 = opts[:s3_driver] || S3Driver.new
     cf = opts[:cf_driver] || CloudFormationDriver.new
-    Application.new(app, bs, s3).delete
+    Application.new(app, bs, s3).destroy
   end
 
 end

--- a/lib/eb_deployer/application.rb
+++ b/lib/eb_deployer/application.rb
@@ -17,7 +17,8 @@ module EbDeployer
       end
     end
 
-    def delete
+    # destroy all environments and application
+    def destroy
       if @eb_driver.application_exists?(@name)
         @eb_driver.environment_names_for_application(@name).each do |env|
           @eb_driver.delete_environment(@name, env)


### PR DESCRIPTION
Consistent use of destroy and related docs to indicate that use of this will destroy all environments under the given elastic beanstalk application.
