### PR TITLE
Added ability to pass bucket name where packages are stored in s3.

### DIFF
--- a/lib/eb_deployer.rb
+++ b/lib/eb_deployer.rb
@@ -112,6 +112,11 @@ module EbDeployer
   #
   # @option opts [Symbol] :settings See `option_settings`
   #
+  # @option opts [Symbol] :bucket Name of s3 bucket where uploaded application
+  # packages will be stored. Note that the string ".packages" will be added as
+  # a suffix to your bucket. So, if "thoughtworks.simple" is passed as the bucket name,
+  # the actual s3 bucket name will be thoughtworks.simple.packages. 
+  #
   # @option opts [Symbol] :smoke_test Value should be a proc or a lambda which
   #   accept single argument that will passed in as environment DNS name. Smoke
   #   test proc or lambda will be called at the end of the deployment for
@@ -166,8 +171,9 @@ module EbDeployer
     cname_prefix = opts[:cname_prefix] || [app, env_name].join('-')
     smoke_test = opts[:smoke_test] || Proc.new {}
     phoenix_mode = opts[:phoenix_mode]
+    bucket = opts[:bucket] || app
 
-    application = Application.new(app, bs, s3)
+    application = Application.new(app, bs, s3, bucket)
 
     cf = CloudFormationProvisioner.new("#{app}-#{env_name}", cf)
 

--- a/lib/eb_deployer/application.rb
+++ b/lib/eb_deployer/application.rb
@@ -1,16 +1,17 @@
 module EbDeployer
   class Application
-    def initialize(name, eb_driver, s3_driver)
+    def initialize(name, eb_driver, s3_driver, bucket = nil)
       @name = name
       @eb_driver = eb_driver
       @s3_driver = s3_driver
+      @bucket = bucket
       raise "application name can only contain any combination of uppercase letters, lowercase letters, numbers, dashes (-)" unless @name =~ /^[a-zA-Z0-9.-]+$/
     end
 
     def create_version(version_label, package)
       create_application_if_not_exists
 
-      package = Package.new(package, @name + "-packages", @s3_driver)
+      package = Package.new(package, @bucket + ".packages", @s3_driver)
       package.upload
 
       unless @eb_driver.application_version_labels.include?(version_label)

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -30,6 +30,7 @@ YAML
 application: myapp
 common:
   strategy: inplace-update
+  bucket: thoughtworks
   phoenix_mode: true
   option_settings:
     - namespace: aws:autoscaling:launchconfiguration
@@ -41,6 +42,7 @@ environments:
   production:
 YAML
     assert_equal('inplace-update', config[:strategy])
+    assert_equal('thoughtworks', config[:bucket])
     assert_equal([{'namespace' => 'aws:autoscaling:launchconfiguration',
                     'option_name' => 'InstanceType',
                     'value' => 'm1.small'}], config[:option_settings])

--- a/test/deploy_test.rb
+++ b/test/deploy_test.rb
@@ -195,6 +195,13 @@ class DeployTest < Minitest::Test
     assert_equal({'a' => 1 },  @cf_driver.stack_config('simple-production')[:parameters])
   end
 
+  def test_set_s3_bucket_name_on_deployment
+    deploy(:application => 'simple',
+           :environment => "production",
+           :bucket => 'thoughtworks.simple')
+
+    assert @s3_driver.bucket_exists?('thoughtworks.simple.packages')
+  end
 
   def test_transforms_resource_provsion_output_to_elastic_beanstalk_settings
     cf_template = temp_file(JSON.dump({


### PR DESCRIPTION
We use multiple AWS accounts and wanted to control the namespace in our s3 storage. This commit adds the ability to pass a bucket name as an option so that the uploaded package file is stored in the desired bucket. It also changes the -packages suffix to .packages so that it's in line with the AWS European bucket naming standard.
