### PR TITLE
Allow passing an object name already uploaded to S3 as package

### DIFF
--- a/lib/eb_deployer/application.rb
+++ b/lib/eb_deployer/application.rb
@@ -11,10 +11,10 @@ module EbDeployer
     def create_version(version_label, package)
       create_application_if_not_exists
 
-      source_bundle = if File.extname(package) == '.yml'
+      source_bundle = if package and File.extname(package) == '.yml'
                         YAML.load(File.read(package))
                       else
-                        package = Package.new(package, @bucket + ".packages", @s3_driver)
+                        package = Package.new(package, version_label, @bucket + ".packages", @s3_driver)
                         package.upload
                         package.source_bundle
                       end

--- a/lib/eb_deployer/package.rb
+++ b/lib/eb_deployer/package.rb
@@ -1,7 +1,7 @@
 module EbDeployer
   class Package
-    def initialize(file, bucket_name, s3_driver)
-      @file, @bucket_name = file, bucket_name
+    def initialize(file, version_label, bucket_name, s3_driver)
+      @file, @version_label, @bucket_name = file, version_label, bucket_name
       @s3 = s3_driver
     end
 
@@ -17,7 +17,7 @@ module EbDeployer
     private
 
     def s3_path
-      @_s3_path ||= Digest::MD5.file(@file).hexdigest + "-" + File.basename(@file)
+      @_s3_path ||= @version_label or Digest::MD5.file(@file).hexdigest + "-" + File.basename(@file)
     end
 
     def ensure_bucket(bucket_name)
@@ -25,7 +25,7 @@ module EbDeployer
     end
 
     def upload_if_not_exists(file, bucket_name)
-      if @s3.object_length(@bucket_name, s3_path) != File.size(file)
+      unless @s3.object_exists?(bucket_name, s3_path)
         log("start uploading to s3 bucket #{@bucket_name}...")
         @s3.upload_file(@bucket_name, s3_path, file)
         log("uploading finished")

--- a/lib/eb_deployer/s3_driver.rb
+++ b/lib/eb_deployer/s3_driver.rb
@@ -8,6 +8,10 @@ module EbDeployer
       buckets[bucket_name].exists?
     end
 
+    def object_exists?(bucket_name, object_name)
+      buckets[bucket_name].objects[object_name].exists?
+    end
+
     def object_length(bucket_name, obj_name)
       obj(bucket_name, obj_name).content_length rescue nil
     end

--- a/test/aws_driver_stubs.rb
+++ b/test/aws_driver_stubs.rb
@@ -159,6 +159,10 @@ class S3Stub
     @buckets[bucket_name]
   end
 
+  def object_exists?(bucket_name, obj_name)
+    @buckets[bucket_name].has_key?(obj_name)
+  end
+
   def object_length(bucket_name, obj_name)
     @buckets[bucket_name][obj_name] && File.size(@buckets[bucket_name][obj_name])
   end

--- a/test/deploy_test.rb
+++ b/test/deploy_test.rb
@@ -403,6 +403,22 @@ class DeployTest < MiniTest::Unit::TestCase
     assert_equal @sample_package, s3_objects.values.first.to_s
   end
 
+  def test_pass_s3_object_name_as_package_file
+    package_name = '512.zip'
+
+    @s3_driver.create_bucket('thoughtworks.simple')
+    @s3_driver.upload_file('thoughtworks.simple', package_name, true)
+
+    deploy(:package => package_name,
+           :application => 'simple',
+           :environment => "production",
+           :package_bucket => 'thoughtworks.simple')
+
+    s3_objects = @s3_driver.objects('thoughtworks.simple.packages')
+    assert_equal 1, s3_objects.size
+    assert_equal package_name, s3_objects.values.first.to_s
+  end
+
   private
 
   def temp_file(content)


### PR DESCRIPTION
In this use case, a CI server creates a build artifact for every build and stores it on S3.
When doing a deployment, we want to reference this already uploaded object on S3 instead of providing a locale file. This change allows to skip the upload on deployment, and instead use the name of an already uploaded object.
