### PR TITLE
Fix S3 upload on Windows

### DIFF
--- a/lib/eb_deployer/aws_driver/s3_driver.rb
+++ b/lib/eb_deployer/aws_driver/s3_driver.rb
@@ -15,7 +15,7 @@ module EbDeployer
 
       def upload_file(bucket_name, obj_name, file)
         o = obj(bucket_name, obj_name)
-        File.open(file) { |f| o.write(f) }
+        File.open(file, 'rb') { |f| o.write(f) }
       end
 
       private


### PR DESCRIPTION
With jruby on Windows, the WAR file uploaded on S3 was corrupted due to the file not being opened in binary mode.
