### PR TITLE
raise an error if the environment launched with problems

### DIFF
--- a/lib/eb_deployer/eb_environment.rb
+++ b/lib/eb_deployer/eb_environment.rb
@@ -100,6 +100,10 @@ module EbDeployer
           raise "Elasticbeanstalk instance provision failed (maybe a problem with your .ebextension files). The original message: #{event[:message]}"
         end
 
+        if event[:message] =~ /However, there were issues during launch\. See event log for details\./
+          raise "Environment launched, but with errors.  The original message: #{event[:message]}"
+        end
+
         log_event(event)
         break if event[:message] =~ terminate_pattern
       end

--- a/test/eb_environment_test.rb
+++ b/test/eb_environment_test.rb
@@ -61,6 +61,17 @@ class EbEnvironmentTest < MiniTest::Unit::TestCase
     assert_raises(RuntimeError) { env.deploy("version 1") }
   end
 
+  def test_should_raise_runtime_error_when_issues_during_launch
+    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    @eb_driver.set_events("myapp", t("production", 'myapp'),
+                          [],
+                          ["start deploying",
+                           "create environment",
+                           "Launched environment: dev-a-1234567. However, there were issues during launch. See event log for details."])
+
+    assert_raises(RuntimeError) { env.deploy("version 1") }
+  end
+
   def test_terminate_should_delete_environment
     env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
     env.deploy("version1")


### PR DESCRIPTION
When such problems happen (often due to a weird timing issue with creating a security group) the polling simply continues indefinitely.
