### PR TITLE
Expose stack_name to SmokeTest module

### DIFF
--- a/lib/eb_deployer/component.rb
+++ b/lib/eb_deployer/component.rb
@@ -2,9 +2,10 @@ module EbDeployer
   class Component
     attr_reader :name
 
-    def initialize(name, env, options, eb_driver)
+    def initialize(name, env, options, stack_name, eb_driver)
       @name = name
       @env = env
+      @stack_name = stack_name
       @eb_driver = eb_driver
       @options = options.dup
       @component_eb_settings = @options.delete(:option_settings) || []
@@ -19,7 +20,7 @@ module EbDeployer
 
     def deploy(version_label, eb_settings, inactive_settings=[])
       @strategy.deploy(version_label,
-                       eb_settings + @component_eb_settings,
+                       eb_settings + @component_eb_settings,                       
                        inactive_settings + @component_inactive_settings)
     end
 
@@ -29,6 +30,7 @@ module EbDeployer
       creation_opts = creation_opts.merge(:cname_prefix => cname_prefix_overriding || cname_prefix)
       EbEnvironment.new(@env.app_name,
                         env_name,
+                        @stack_name,
                         @eb_driver,
                         creation_opts)
 

--- a/lib/eb_deployer/default_component.rb
+++ b/lib/eb_deployer/default_component.rb
@@ -1,7 +1,8 @@
 module EbDeployer
   class DefaultComponent
-    def initialize(env, creation_opts, strategy_name, eb_driver)
+    def initialize(env, creation_opts, strategy_name, stack_name, eb_driver)
       @env = env
+      @stack_name = stack_name
       @eb_driver = eb_driver
       @creation_opts = creation_opts
       @strategy = DeploymentStrategy.create(self, strategy_name)
@@ -19,6 +20,7 @@ module EbDeployer
     def new_eb_env(suffix=nil, cname_prefix_overriding=nil)
       EbEnvironment.new(@env.app_name,
                         [@env.name, suffix].compact.join('-'),
+                        @stack_name,
                         @eb_driver,
                         @creation_opts.merge(:cname_prefix => cname_prefix_overriding || cname_prefix))
     end

--- a/lib/eb_deployer/eb_environment.rb
+++ b/lib/eb_deployer/eb_environment.rb
@@ -11,8 +11,9 @@ module EbDeployer
       "#{env_name}-#{digest}"
     end
 
-    def initialize(app, name, eb_driver, creation_opts={})
+    def initialize(app, name, stack_name, eb_driver, creation_opts={})
       @app = app
+      @stack_name = stack_name
       @name = self.class.unique_ebenv_name(name, app)
       @bs = eb_driver
       @creation_opts = default_create_options.merge(reject_nil(creation_opts))
@@ -85,7 +86,7 @@ module EbDeployer
 
     def smoke_test
       host_name = @bs.environment_cname(@app, @name)
-      SmokeTest.new(@creation_opts[:smoke_test]).run(host_name, self)
+      SmokeTest.new(@creation_opts[:smoke_test]).run(host_name, @stack_name, self)
     end
 
     def with_polling_events(terminate_pattern, &block)

--- a/lib/eb_deployer/environment.rb
+++ b/lib/eb_deployer/environment.rb
@@ -18,7 +18,7 @@ module EbDeployer
       @strategy_name = :blue_green
       yield(self) if block_given?
       unless @components
-        @components = [DefaultComponent.new(self, @creation_opts, @strategy_name, @eb_driver)]
+        @components = [DefaultComponent.new(self, @creation_opts, @strategy_name, @stack_name, @eb_driver)]
       end
     end
 
@@ -37,7 +37,7 @@ module EbDeployer
       return unless components_attrs
       @components = components_attrs.map do |attrs|
         attrs = symbolize_keys(attrs)
-        Component.new(attrs.delete(:name), self, attrs, @eb_driver)
+        Component.new(attrs.delete(:name), self, attrs, @stack_name, @eb_driver)
       end
     end
 

--- a/lib/eb_deployer/smoke_test.rb
+++ b/lib/eb_deployer/smoke_test.rb
@@ -4,13 +4,13 @@ module EbDeployer
       @test_body = test_body
     end
 
-    def run(host_name, logger=nil)
+    def run(host_name, stack_name, logger=nil)
       return unless @test_body
-      logger.log("running smoke test for #{host_name}...") if logger
+      logger.log("running smoke test for #{host_name}/#{stack_name}...") if logger
 
       case @test_body
       when Proc
-        @test_body.call(host_name)
+        @test_body.call(host_name, stack_name)
       when String
         eval(@test_body, binding)
       else

--- a/test/blue_green_deploy_test.rb
+++ b/test/blue_green_deploy_test.rb
@@ -29,14 +29,14 @@ class BlueGreenDeployTest < DeployTest
 
   def test_blue_green_deploy_should_run_smoke_test_before_cname_switch
     smoked_host = []
-    smoke_test = lambda { |host| smoked_host << host }
+    smoke_test = lambda { |host,smoke| smoked_host << host + " " + smoke }
     [42, 43, 44].each do |version_label|
       do_deploy(version_label, :smoke_test => smoke_test)
     end
 
-    assert_equal ['simple-production.elasticbeanstalk.com',
-                  'simple-production-inactive.elasticbeanstalk.com',
-                  'simple-production-inactive.elasticbeanstalk.com'], smoked_host
+    assert_equal ['simple-production.elasticbeanstalk.com simple-production',
+                  'simple-production-inactive.elasticbeanstalk.com simple-production',
+                  'simple-production-inactive.elasticbeanstalk.com simple-production'], smoked_host
   end
 
 

--- a/test/blue_only_deploy_test.rb
+++ b/test/blue_only_deploy_test.rb
@@ -31,14 +31,14 @@ class BlueOnlyDeployTest < DeployTest
 
   def test_blue_only_deploy_should_run_smoke_test_before_cname_switch
     smoked_host = []
-    smoke_test = lambda { |host| smoked_host << host }
+    smoke_test = lambda { |host,stack| smoked_host << host + "+" + stack}
     [42, 43, 44].each do |version_label|
       do_deploy(version_label, :smoke_test => smoke_test)
     end
 
-    assert_equal ['simple-production.elasticbeanstalk.com',
-                  'simple-production-inactive.elasticbeanstalk.com',
-                  'simple-production-inactive.elasticbeanstalk.com'], smoked_host
+    assert_equal ['simple-production.elasticbeanstalk.com+simple-production',
+                  'simple-production-inactive.elasticbeanstalk.com+simple-production',
+                  'simple-production-inactive.elasticbeanstalk.com+simple-production'], smoked_host
   end
 
 

--- a/test/eb_environment_test.rb
+++ b/test/eb_environment_test.rb
@@ -7,13 +7,13 @@ class EbEnvironmentTest < MiniTest::Unit::TestCase
   end
 
   def test_deploy_should_create_corresponding_eb_env
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver)
     env.deploy("version1")
     assert @eb_driver.environment_exists?('myapp', t('production', 'myapp'))
   end
 
   def test_deploy_again_should_update_environment
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver)
     env.deploy("version1")
     env.deploy("version2")
     assert @eb_driver.environment_exists?('myapp', t('production', 'myapp'))
@@ -21,20 +21,20 @@ class EbEnvironmentTest < MiniTest::Unit::TestCase
   end
 
   def test_option_setttings_get_set_on_eb_env
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver)
     env.deploy("version1", {s1: 'v1'})
     assert_equal({s1: 'v1' },  @eb_driver.environment_settings('myapp', t('production', 'myapp')))
   end
 
   def test_deploy_should_include_tags
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver, {:tags => {:my_tag => 'my_value', :tag2 => 'value2'}})
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver, {:tags => {:my_tag => 'my_value', :tag2 => 'value2'}})
     env.deploy("version1")
     assert_equal [{:key => :my_tag, :value => 'my_value'}, {:key => :tag2, :value => 'value2'}], @eb_driver.environment_tags('myapp', t('production', 'myapp'))
   end
 
   def test_should_run_smoke_test_after_deploy
     smoked_host = nil
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver, :smoke_test => Proc.new { |host| smoked_host = host })
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver, :smoke_test => Proc.new { |host| smoked_host = host })
     env.deploy("version1")
 
     assert !smoked_host.nil?
@@ -42,7 +42,7 @@ class EbEnvironmentTest < MiniTest::Unit::TestCase
   end
 
   def test_should_raise_runtime_error_when_deploy_failed
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver)
     @eb_driver.set_events("myapp", t("production", 'myapp'),
                           [],
                           ["start deploying", "Failed to deploy application"])
@@ -50,7 +50,7 @@ class EbEnvironmentTest < MiniTest::Unit::TestCase
   end
 
   def test_should_raise_runtime_error_when_eb_extension_execution_failed
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver)
     @eb_driver.set_events("myapp", t("production", 'myapp'),
                           [],
                           ["start deploying",
@@ -62,7 +62,7 @@ class EbEnvironmentTest < MiniTest::Unit::TestCase
   end
 
   def test_should_raise_runtime_error_when_issues_during_launch
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver)
     @eb_driver.set_events("myapp", t("production", 'myapp'),
                           [],
                           ["start deploying",
@@ -73,14 +73,14 @@ class EbEnvironmentTest < MiniTest::Unit::TestCase
   end
 
   def test_terminate_should_delete_environment
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver)
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver)
     env.deploy("version1")
     env.terminate
     assert !@eb_driver.environment_exists?('myapp', t('production', 'myapp'))
   end
 
   def test_should_raise_runtime_error_when_solution_stack_is_not_valid
-    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver, {
+    env = EbDeployer::EbEnvironment.new("myapp", "production", "myapp-prod", @eb_driver, {
                                           :solution_stack => "python"
                                         })
     @eb_driver.set_solution_stacks(["java", "ruby"])

--- a/test/inplace_update_deploy_test.rb
+++ b/test/inplace_update_deploy_test.rb
@@ -48,21 +48,25 @@ class InplaceUpdateDeployTest < DeployTest
 
   def test_smoke_test_should_be_run_after_env_created_or_update
     host_for_smoke_test = nil
+    stack_for_smoke_test = nil
     deploy(:application => 'simple',
            :environment => "production",
            :cname_prefix => 'foobar',
-           :smoke_test => lambda { |host| host_for_smoke_test = host },
+           :smoke_test => lambda { |host, stack| host_for_smoke_test = host; stack_for_smoke_test = stack },
            :version_label => 42)
     assert_equal 'foobar.elasticbeanstalk.com', host_for_smoke_test
+    assert_equal 'simple-production', stack_for_smoke_test
 
     host_for_smoke_test = nil
+    stack_for_smoke_test = nil
     deploy(:application => 'simple',
            :environment => "production",
            :cname_prefix => 'foobar',
-           :smoke_test => lambda { |host| host_for_smoke_test = host },
+           :smoke_test => lambda { |host, stack| host_for_smoke_test = host; stack_for_smoke_test = stack },
            :version_label => 43)
 
     assert_equal 'foobar.elasticbeanstalk.com', host_for_smoke_test
+    assert_equal 'simple-production', stack_for_smoke_test
   end
 
   def test_should_terminate_old_environment_if_phoenix_mode_is_enabled

--- a/test/smoke_test_test.rb
+++ b/test/smoke_test_test.rb
@@ -3,20 +3,25 @@ require 'test_helper'
 class SmokeTestTest < MiniTest::Unit::TestCase
   def test_call_proc_type_smoke_tests
     host_name_in_proc = nil
-    EbDeployer::SmokeTest.new(lambda {|v| host_name_in_proc = v }).run("foo")
-
+    stack_name_in_proc = nil
+    EbDeployer::SmokeTest.new(lambda {|v, u| host_name_in_proc = v; stack_name_in_proc = u }).run("foo", "bar")
+    
     assert_equal 'foo', host_name_in_proc
+    assert_equal 'bar', stack_name_in_proc
   end
 
   def test_eval_string_type_smoke_test
     $host_name_in_proc = nil
-    EbDeployer::SmokeTest.new("$host_name_in_proc=host_name").run("foo")
+    $stack_name_in_proc = nil
+    EbDeployer::SmokeTest.new("$host_name_in_proc=host_name; $stack_name_in_proc=stack_name").run("foo", "bar")
+
     assert_equal 'foo', $host_name_in_proc
+    assert_equal 'bar', $stack_name_in_proc
   end
 
   def test_should_raise_if_test_body_raise
     assert_raises(RuntimeError) do
-      EbDeployer::SmokeTest.new("raise host_name").run("foo")
+      EbDeployer::SmokeTest.new("raise host_name").run("foo", "bar")
     end
   end
 


### PR DESCRIPTION
The use case is that we want to run smoke tests for an auxillary service
in our VPC without a public IP. By passing the stack name to the smoke
test, we can make it look up the public IP of the jumphost for that
stack, and execute the smoke tests via that.
