### PR TITLE
Removed cname from the create environment command

### DIFF
--- a/lib/eb_deployer/aws_driver/beanstalk.rb
+++ b/lib/eb_deployer/aws_driver/beanstalk.rb
@@ -48,9 +48,10 @@ module EbDeployer
           :version_label => version,
           :option_settings => settings,
           :tier => environment_tier(tier),
-          :tags => tags,
-          :cname_prefix => cname_prefix
+          :tags => tags
         }
+
+        request[:cname_prefix] = cname_prefix if tier.downcase == 'webserver'
 
         @client.create_environment(request)
       end


### PR DESCRIPTION
When a worker is created there is an error from AWS because the cname_prefix cannot be used unless you are creating a webserver. This is the cause of [issue-35](https://github.com/ThoughtWorksStudios/eb_deployer/issues/35).

This solution just moves the cname_prefix into an if so that both environment types will work