### PR TITLE
Red/Black deployment strategy

### DIFF
--- a/lib/eb_deployer/default_config.yml
+++ b/lib/eb_deployer/default_config.yml
@@ -12,12 +12,14 @@ common:
   # AWS region to deploy. Default to us-east-1
   # region: us-west-1
 
-  # There are three deployment strategies: 'blue-green', 'blue-only', or 'inplace-update'.
+  # There are four deployment strategies: 'blue-green', 'blue-only', 'red-black' or 'inplace-update'.
   # Blue green deployments keep two elastic beanstalk environments and always deploy to
   # inactive one, to achieve zero downtime.
   # Blue only deployments do everything that the blue green deployments do except for the final
   # inactive to active CNAME swap leaving the newly deployed application on the inactive
   # "blue" instance.
+  # Red black deployments are similar to Blue Green, in that a new stack is created beside the live
+  # stack, however the inactive environment is terminated upon successful deployment of the new stack. 
   # Inplace-update strategy will only keep one environment, and update the version inplace on
   # deploy. Inplace-update will save resources but will suffer from downtime.
   # (All old environments need be destroyed when you switching between strategies.)

--- a/lib/eb_deployer/deployment_strategy.rb
+++ b/lib/eb_deployer/deployment_strategy.rb
@@ -1,6 +1,7 @@
 require 'eb_deployer/deployment_strategy/inplace_update'
 require 'eb_deployer/deployment_strategy/blue_green'
 require 'eb_deployer/deployment_strategy/blue_only'
+require 'eb_deployer/deployment_strategy/red_black'
 
 module EbDeployer
   module DeploymentStrategy
@@ -12,6 +13,8 @@ module EbDeployer
         BlueGreen.new(component)
       when 'blue_only', 'blue-only'
         BlueOnly.new(component)
+      when 'red_black', 'red-black'
+        RedBlack.new(component)
       else
         raise 'strategy_name: ' + strategy_name.to_s + ' not supported'
       end

--- a/lib/eb_deployer/deployment_strategy/red_black.rb
+++ b/lib/eb_deployer/deployment_strategy/red_black.rb
@@ -1,0 +1,65 @@
+module EbDeployer
+  module DeploymentStrategy
+    class RedBlack
+      def initialize(component)
+        @component = component
+
+        # Force 'phoenix mode' to true?
+      end
+
+      def test_compatibility(env_create_options)
+        tier = env_create_options[:tier]
+        if tier && tier.downcase == 'worker'
+          raise "Red/Black deployment is not supported for Worker tier"
+        end
+      end
+
+      def deploy(version_label, env_settings, inactive_settings=[])
+        if !ebenvs.any?(&method(:active_ebenv?))
+          ebenv('a', @component.cname_prefix).
+            deploy(version_label, env_settings)
+          return
+        end
+
+        active_ebenv = ebenvs.detect(&method(:active_ebenv?))
+        inactive_ebenv = ebenvs.reject(&method(:active_ebenv?)).first
+
+        inactive_ebenv.deploy(version_label, env_settings)
+        active_ebenv.swap_cname_with(inactive_ebenv)
+        unless inactive_settings.empty?
+          active_ebenv.log("applying inactive settings...")
+          active_ebenv.apply_settings(inactive_settings)
+        end
+
+        if inactive_ebenv.health_state == 'Green'
+          log("Active environment healthy, terminating inactive (black) environment")
+          active_ebenv.terminate
+        else
+          log("Active environment changed state to unhealthy. Existing (black) environment will not be terminated")
+        end
+
+      end
+
+      private
+      def active_ebenv?(ebenv)
+        ebenv.cname_prefix == @component.cname_prefix
+      end
+
+      def ebenvs
+        [ebenv('a'), ebenv('b')]
+      end
+
+      def ebenv(suffix, cname_prefix=nil)
+        @component.new_eb_env(suffix, cname_prefix || inactive_cname_prefix)
+      end
+
+      def inactive_cname_prefix
+        "#{@component.cname_prefix}-inactive"
+      end
+
+      def log(msg)
+        puts "[#{Time.now.utc}][application:#{@name}] #{msg}"
+      end
+    end
+  end
+end

--- a/lib/eb_deployer/eb_environment.rb
+++ b/lib/eb_deployer/eb_environment.rb
@@ -61,6 +61,10 @@ module EbDeployer
       end
     end
 
+    def health_state
+      @bs.environment_health_state(@app, @name)
+    end
+
     private
 
     def configured_tier

--- a/test/red_black_deploy_test.rb
+++ b/test/red_black_deploy_test.rb
@@ -1,0 +1,70 @@
+require 'deploy_test'
+
+class RedBlackDeployTest < DeployTest
+  def test_red_black_deployment_strategy_should_create_red_env_on_first_deployment
+    do_deploy(42)
+    assert @eb.environment_exists?('simple', t('production-a', 'simple'))
+    assert_equal 'simple-production',  @eb.environment_cname_prefix('simple', t('production-a', 'simple'))
+  end
+
+
+  def test_red_black_deployment_should_create_black_env_if_red_exists
+    do_deploy(42)
+    do_deploy(43)
+    assert !@eb.environment_exists?('simple', t('production-a', 'simple'))
+    assert @eb.environment_exists?('simple', t('production-b', 'simple'))
+  end
+
+  def test_red_black_deployment_should_terminate_inactive_environment_on_successful_deploy
+    do_deploy(42)
+    do_deploy(43)
+    inactive_env = t('production-a', 'simple')
+    assert_equal [inactive_env], @eb.environments_been_deleted('simple')
+    assert_equal 'simple-production',  @eb.environment_cname_prefix('simple', t('production-b', 'simple'))
+    do_deploy(44)
+    inactive_env2 = t('production-b', 'simple')
+    assert_equal [inactive_env, inactive_env2], @eb.environments_been_deleted('simple')
+    assert_equal 'simple-production',  @eb.environment_cname_prefix('simple', t('production-a', 'simple'))
+  end
+
+  def test_red_black_deployment_should_swap_cname_to_make_active_most_recent_updated_env
+    do_deploy(42)
+    do_deploy(43)
+    assert_equal 'simple-production',  @eb.environment_cname_prefix('simple', t('production-b', 'simple'))
+    do_deploy(44)
+    assert_equal 'simple-production',  @eb.environment_cname_prefix('simple', t('production-a', 'simple'))
+  end
+
+
+  def test_red_black_deploy_should_run_smoke_test_before_cname_switch
+    smoked_host = []
+    smoke_test = lambda { |host| smoked_host << host }
+    [42, 43, 44].each do |version_label|
+      do_deploy(version_label, :smoke_test => smoke_test)
+    end
+
+    assert_equal ['simple-production.elasticbeanstalk.com',
+                  'simple-production-inactive.elasticbeanstalk.com',
+                  'simple-production-inactive.elasticbeanstalk.com'], smoked_host
+  end
+
+  def test_destroy_should_clean_up_env
+    [42, 44].each do |version|
+      do_deploy(version)
+    end
+
+    destroy(:application => 'simple', :environment => 'production')
+    assert !@eb.environment_exists?('simple', t('production-a', 'simple'))
+    assert !@eb.environment_exists?('simple', t('production-b', 'simple'))
+  end
+
+  private
+
+  def do_deploy(version_label, options={})
+    deploy( {:application => 'simple',
+              :environment => "production",
+              :strategy => 'red-black',
+            }.merge(options).merge(:version_label => version_label))
+  end
+
+end


### PR DESCRIPTION
This feature introduces a new Strategy, which is really a fresh take on the Blue Green approach.
In short, in many cases its ideal to remove the inactive stack post deployment - generally for keeping costs down.

This strategy follows the Blue Green approach, but will tear down a stack after a successful migration to the new 'Red' Environment, marking the old one as 'black' and terminating.

It should be noted that I considered modifying the existing Blue-Green strategy, but felt it was best to separate for the following reasons:

1. Existing users should not be confused by the new strategy
2. I didn't want to complicate the behaviour of the pattern further by introducing more knobs/levers 
3. We may want to modify the Red/Black pattern to do other things going forward, such as introducing a wait period/signal before terminating the inactive environment and so on.

What are your thoughts?