### PR TITLE
In many cases its ideal to remove the inactive stack post deployment …

### DIFF
--- a/lib/eb_deployer.rb
+++ b/lib/eb_deployer.rb
@@ -171,7 +171,7 @@ module EbDeployer
   #   version_prefix is given, only removes version starting with the prefix.
   def self.deploy(opts)
     if region = opts[:region]
-      Aws.config.update(:region => region)
+      Aws.config.update({:region => region})
     end
 
     bs = opts[:bs_driver] || AWSDriver::Beanstalk.new

--- a/lib/eb_deployer.rb
+++ b/lib/eb_deployer.rb
@@ -40,7 +40,7 @@ module EbDeployer
   #
   def self.query_resource_output(key, opts)
     if region = opts[:region]
-      AWS.config(:region => region)
+      Aws.config.update({:region => region})
     end
     app = opts[:application]
     env_name = opts[:environment]
@@ -181,6 +181,7 @@ module EbDeployer
 
     app_name = opts[:application]
     env_name = opts[:environment]
+    @opts = {:foo => "bar"}
     version_prefix = opts[:version_prefix].to_s.strip
     version_label = "#{version_prefix}#{opts[:version_label].to_s.strip}"
 
@@ -200,6 +201,9 @@ module EbDeployer
         :cname_prefix =>  opts[:cname_prefix],
         :smoke_test => opts[:smoke_test],
         :phoenix_mode => opts[:phoenix_mode],
+        :blue_green_terminate_inactive => opts[:blue_green_terminate_inactive] || false,
+        :blue_green_terminate_inactive_wait => opts[:blue_green_terminate_inactive_wait] || 600,
+        :blue_green_terminate_inactive_sleep => opts[:blue_green_terminate_inactive_sleep] || 15,
         :tags => opts[:tags],
         :tier => opts[:tier]
       }
@@ -215,7 +219,7 @@ module EbDeployer
 
   def self.destroy(opts)
     if region = opts[:region]
-      AWS.config(:region => region)
+      Aws.config.update({:region => region})
     end
 
     app = opts[:application]
@@ -297,7 +301,7 @@ module EbDeployer
         require 'logger'
         logger = Logger.new($stdout)
         logger.level = Logger::DEBUG
-        AWS.config(:logger => logger)
+        Aws.config.update({:logger => logger})
       end
 
       opts.on("-h", "--help", "help")  do

--- a/lib/eb_deployer/application.rb
+++ b/lib/eb_deployer/application.rb
@@ -68,9 +68,9 @@ module EbDeployer
         begin
           log("Removing #{version}")
           @eb_driver.delete_application_version(@name, version, delete_from_s3)
-        rescue AWS::ElasticBeanstalk::Errors::SourceBundleDeletionFailure => e
+        rescue Aws::ElasticBeanstalk::Errors::SourceBundleDeletionFailure => e
           log(e.message)
-        rescue AWS::ElasticBeanstalk::Errors::OperationInProgressFailure => e
+        rescue Aws::ElasticBeanstalk::Errors::OperationInProgressFailure => e
           log(e.message)
         end
       end

--- a/lib/eb_deployer/eb_environment.rb
+++ b/lib/eb_deployer/eb_environment.rb
@@ -61,6 +61,10 @@ module EbDeployer
       end
     end
 
+    def health_state
+      @bs.environment_health_state(@app, @name)
+    end
+
     private
 
     def configured_tier

--- a/lib/eb_deployer/utils.rb
+++ b/lib/eb_deployer/utils.rb
@@ -4,7 +4,7 @@ module EbDeployer
 
     # A util deal with throttling exceptions
     # example:
-    #  backoff(AWS::EC2::Errors::RequestLimitExceeded) do
+    #  backoff(Aws::EC2::Errors::RequestLimitExceeded) do
     #     ...
     #  end
     def backoff(error_class, retry_limit=9, &block)

--- a/lib/eb_deployer/version.rb
+++ b/lib/eb_deployer/version.rb
@@ -1,3 +1,3 @@
 module EbDeployer
-  VERSION = "0.6.0.beta5"
+  VERSION = "0.6.0.beta6"
 end

--- a/lib/generators/eb_deployer/install/install_generator.rb
+++ b/lib/generators/eb_deployer/install/install_generator.rb
@@ -59,7 +59,7 @@ YAML
       end
 
       def solution_stack_name
-        AWS::ElasticBeanstalk.Client.new.list_available_solution_stacks[:solution_stacks].find do |s|
+        Aws::ElasticBeanstalk.Client.new.list_available_solution_stacks[:solution_stacks].find do |s|
           s =~ /Amazon Linux/ && s =~ /running Ruby 2.1 \(Passenger Standalone\)/
         end
       rescue

--- a/lib/generators/eb_deployer/install/templates/eb_deployer.yml.erb
+++ b/lib/generators/eb_deployer/install/templates/eb_deployer.yml.erb
@@ -37,6 +37,21 @@ common:
   # you override it to 'on' for production environment.
   # phoenix_mode: false
 
+  # Terminates the inactive stack upon successful blue-green deployment.
+  # This is useful if you require HA deployment but don't want the cost of running
+  # a stack that is not in use. See https://github.com/ThoughtWorksStudios/eb_deployer/pull/44/
+  # for other strategies that can be employed.
+  # Note: As EB Deployer uses DNS to switch between stacks, this should be used only if you
+  #       both put in a sufficient wait period and accept the risk that traffic may still be
+  #       going to the inactive stack when it is terminated, due to client DNS caching, for example.
+  #blue_green_terminate_inactive: false
+
+  # How long to wait before terminating the inactive stack if 'blue_green_terminate_inactive' is set to true.
+  #blue_green_terminate_inactive_wait: 600
+
+  # How often to check for changes to the inactive stack during the 'blue_green_terminate_inactive_wait' period.
+  #blue_green_terminate_inactive_sleep: 15
+
   # Specifies the maximum number of versions to keep. Older versions are removed
   # and deleted from the S3 source bucket as well. If specified as zero or not
   # specified, all versions will be kept.  If a version_prefix is given, only removes

--- a/test/blue_green_deploy_test.rb
+++ b/test/blue_green_deploy_test.rb
@@ -39,6 +39,13 @@ class BlueGreenDeployTest < DeployTest
                   'simple-production-inactive.elasticbeanstalk.com'], smoked_host
   end
 
+  def test_blue_green_deploy_should_blue_green_terminate_inactive_env_if_blue_green_terminate_inactive_is_enabled
+    do_deploy(42, :blue_green_terminate_inactive => true, :blue_green_terminate_inactive_wait => 1, :blue_green_terminate_inactive_sleep => 1)
+    do_deploy(43, :blue_green_terminate_inactive => true, :blue_green_terminate_inactive_wait => 0, :blue_green_terminate_inactive_sleep => 0)
+
+    inactive_env = t('production-a', 'simple')
+    assert_equal [inactive_env], @eb.environments_been_deleted('simple')
+  end
 
   def test_blue_green_deployment_should_delete_and_recreate_inactive_env_if_phoenix_mode_is_enabled
     do_deploy(42, :phoenix_mode => true)


### PR DESCRIPTION
In many cases its ideal to remove the inactive stack post deployment - generally for keeping costs down. See #44 for background and discussion.

This feature introduces a new set of configuration options for the blue-green strategy, enabling a red/black style deployment where the inactive stack is removed upon a successful deployment of a new stack.

The 3 top-level options introduced are:

  * `blue_green_terminate_inactive` with `false` as the default.
  * `blue_green_terminate_inactive_wait` with `600`s as the default. This option waits the specified period of time before termination happens.
  * `blue_green_terminate_inactive_sleep` with `15`s as the default. This option specifies the interval to check if the new stack turns red, preventing the termination of the new environment.

These options are further documented in the configuration template.

Additionally, this commit fixes some issues with `Aws` namespace to be compliant with v2+ of the [AWS SDK](https://github.com/aws/aws-sdk-ruby)