### PR TITLE
Accept yellow health flag

### DIFF
--- a/lib/eb_deployer.rb
+++ b/lib/eb_deployer.rb
@@ -204,6 +204,7 @@ module EbDeployer
         :cname_prefix =>  opts[:cname_prefix],
         :smoke_test => opts[:smoke_test],
         :phoenix_mode => opts[:phoenix_mode],
+        :accepted_healthy_states => opts[:accepted_healthy_states],
         :blue_green_terminate_inactive => opts[:blue_green_terminate_inactive] || false,
         :blue_green_terminate_inactive_wait => opts[:blue_green_terminate_inactive_wait] || 600,
         :blue_green_terminate_inactive_sleep => opts[:blue_green_terminate_inactive_sleep] || 15,

--- a/lib/eb_deployer.rb
+++ b/lib/eb_deployer.rb
@@ -91,6 +91,11 @@ module EbDeployer
   #   For all available options take a look at
   #   http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html
   #
+  # @option opts [Symbol] :accepted_healthy_states (['Green']) If :accepted_healthy_states
+  #   is specified, EBDeployer will accept provided values when checking
+  #   health of an environment instead of default value 'Green'. You can use it
+  #   to specify additional healthy states, for example: ['Green', "Yellow"]
+  #
   # @option opts [Symbol] :phoenix_mode (false) If phoenix mode is turn on, it
   #   will terminate the old elastic beanstalk environment and recreate on
   #   deploy. For blue-green deployment it terminate the inactive environment

--- a/lib/eb_deployer/default_config.yml
+++ b/lib/eb_deployer/default_config.yml
@@ -83,7 +83,16 @@ common:
       end
     end
 
-
+  # List of Elastic Beanstalk health states that will be considered healthy when deploying.
+  # You may want to override default 'Green' with that list, if for example you are using
+  # Elastic Beanstalk worker tier and you don't want eb_deployer to fail if you have messages
+  # in your SQS queue.
+  # By default eb_deployer only considers 'Green' as the healthy state.
+  # For a list of all Elastic Beanstalk health states refer to:
+  # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.healthstatus.html#using-features.healthstatus.colors
+  # accepted_healthy_states:
+  #  - Green
+  #  - Yellow
 
   # Elastic Beanstalk settings that will apply to the environments you are
   # deploying.

--- a/lib/eb_deployer/eb_environment.rb
+++ b/lib/eb_deployer/eb_environment.rb
@@ -16,6 +16,7 @@ module EbDeployer
       @name = self.class.unique_ebenv_name(name, app)
       @bs = eb_driver
       @creation_opts = default_create_options.merge(reject_nil(creation_opts))
+      @accepted_healthy_states = @creation_opts[:accepted_healthy_states]
     end
 
     def deploy(version_label, settings={})
@@ -162,8 +163,7 @@ module EbDeployer
     def wait_for_env_become_healthy
       Timeout.timeout(600) do
         current_health_status = @bs.environment_health_state(@app, @name)
-
-        while current_health_status != 'Green'
+        while !@accepted_healthy_states.include?(current_health_status)
           log("health status: #{current_health_status}")
           sleep 15
           current_health_status = @bs.environment_health_state(@app, @name)
@@ -181,7 +181,8 @@ module EbDeployer
       {
         :solution_stack => "64bit Amazon Linux 2014.09 v1.1.0 running Tomcat 7 Java 7",
         :smoke_test =>  Proc.new {},
-        :tier => 'WebServer'
+        :tier => 'WebServer',
+        :accepted_healthy_states => ['Green']
       }
     end
 

--- a/lib/generators/eb_deployer/install/templates/eb_deployer.yml.erb
+++ b/lib/generators/eb_deployer/install/templates/eb_deployer.yml.erb
@@ -89,6 +89,17 @@ common:
       end
     end
 
+  # List of Elastic Beanstalk health states that will be considered healthy when deploying.
+  # You may want to override default 'Green' with that list, if for example you are using
+  # Elastic Beanstalk worker tier and you don't want eb_deployer to fail if you have messages
+  # in your SQS queue.
+  # By default eb_deployer only considers 'Green' as the healthy state.
+  # For a list of all Elastic Beanstalk health states refer to:
+  # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.healthstatus.html#using-features.healthstatus.colors
+  # accepted_healthy_states:
+  #  - Green
+  #  - Yellow
+
   # Elastic Beanstalk settings that will apply to the environments you are
   # deploying.
   # For all available options take a look at

--- a/test/aws_driver_stubs.rb
+++ b/test/aws_driver_stubs.rb
@@ -7,6 +7,7 @@ class EBStub
     @envs_been_deleted = {}
     @versions_deleted = {}
     @event_fetched_times = 0
+    @envs_health_states = {}
   end
 
   def create_application(app)
@@ -166,7 +167,7 @@ class EBStub
   end
 
   def environment_health_state(app_name, env_name)
-    'Green'
+    @envs_health_states.fetch(app_name+env_name, 'Green')
   end
 
   def environment_verion_label(app_name, env_name)
@@ -178,6 +179,11 @@ class EBStub
   end
 
   #test only
+
+  def mark_env_health_state_as(app_name, env_name, state)
+    @envs_health_states[app_name+env_name] = state
+  end
+
   def mark_all_envs_ready
     @envs.values.each { |env| set_env_ready(env[:application], env[:name], true) }
   end

--- a/test/eb_environment_test.rb
+++ b/test/eb_environment_test.rb
@@ -103,6 +103,7 @@ class EbEnvironmentTest < Test::Unit::TestCase
     env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver, :accepted_healthy_states => ["Green", "Yellow"])
     @eb_driver.mark_env_health_state_as("myapp", env.name, "Yellow")
     env.deploy("version1")
+    assert @eb_driver.environment_exists?('myapp', t('production', 'myapp'))
   end
 
 end

--- a/test/eb_environment_test.rb
+++ b/test/eb_environment_test.rb
@@ -99,5 +99,10 @@ class EbEnvironmentTest < Test::Unit::TestCase
     assert_nil @eb_driver.environment_cname_prefix('myapp', t('production', 'myapp'))
   end
 
+  def test_should_be_possible_to_accept_yellow_health_state
+    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver, :accepted_healthy_states => ["Green", "Yellow"])
+    @eb_driver.mark_env_health_state_as("myapp", env.name, "Yellow")
+    env.deploy("version1")
+  end
 
 end


### PR DESCRIPTION
Pull request for https://github.com/ThoughtWorksStudios/eb_deployer/issues/66

We introduced optional 'accepted_healthy_states' config option, that let's you specify a list of valid states, for example:

```
accepted_healthy_states:
    - Green
    - Yellow
```

Happy to hear any feedback and improve it as needed. Otherwise we tested it and it works for our use-case. Default behaviour didn't change.