### PR TITLE
Environment updates can complete with errors

### DIFF
--- a/lib/eb_deployer/eb_environment.rb
+++ b/lib/eb_deployer/eb_environment.rb
@@ -136,6 +136,10 @@ module EbDeployer
           raise "Elasticbeanstalk instance provision failed (maybe a problem with your .ebextension files). The original message: #{event[:message]}"
         end
 
+        if event[:message] =~ /complete, but with errors/
+          raise event[:message]
+        end
+
         if event[:message] =~ /However, there were issues during launch\. See event log for details\./
           raise "Environment launched, but with errors.  The original message: #{event[:message]}"
         end

--- a/test/eb_environment_test.rb
+++ b/test/eb_environment_test.rb
@@ -61,6 +61,17 @@ class EbEnvironmentTest < Test::Unit::TestCase
     assert_raises(RuntimeError) { env.deploy("version 1") }
   end
 
+  def test_should_raise_runtime_error_when_issues_during_environment_update
+    env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver, :cname_prefix => 'myapp-production')
+    @eb_driver.set_events("myapp", t("production", 'myapp'),
+                          [],
+                          ["start deploying",
+                           "create environment",
+                           "Update environment operation is complete, but with errors. For more information, see troubleshooting documentation."])
+
+    assert_raises(RuntimeError) { env.deploy("version 1") }
+  end
+
   def test_should_raise_runtime_error_when_issues_during_launch
     env = EbDeployer::EbEnvironment.new("myapp", "production", @eb_driver, :cname_prefix => 'myapp-production')
     @eb_driver.set_events("myapp", t("production", 'myapp'),


### PR DESCRIPTION
We are seeing a lot of timeouts of our automated build. We noticed that the following case was not yet handled:

 [2016-07-13 02:23:14 UTC][environment:develop-api-b-97e0757] Update environment operation is complete, but with errors. For more information, see troubleshooting documentation.

